### PR TITLE
Control backend testing

### DIFF
--- a/.github/workflows/deploy-control-backend.yml
+++ b/.github/workflows/deploy-control-backend.yml
@@ -75,11 +75,15 @@ jobs:
       - name: Validate staged map assets
         run: bash map-source/stage-map-assets.sh --check
 
-      - name: Build backend with Maven
+      # Tests run here as well as in test-control-backend.yml. That workflow is
+      # the fast PR signal; this one is the gate that a direct push to main or a
+      # workflow_dispatch cannot route around. `package` runs the suite by
+      # default, so a red test fails the build well before the first EC2 step.
+      - name: Build and test backend with Maven
         working-directory: control-backend
         run: |
           set -Eeuo pipefail
-          mvn --batch-mode --no-transfer-progress clean package -DskipTests
+          mvn --batch-mode --no-transfer-progress clean package
 
       - name: Find built JAR
         id: find-jar

--- a/.github/workflows/test-control-backend.yml
+++ b/.github/workflows/test-control-backend.yml
@@ -1,22 +1,5 @@
 # Runs the control-backend test suite on pull requests and pushes.
-#
-# Deliberately a separate workflow from deploy-control-backend.yml. That one
-# holds a workflow-level `concurrency: control-platform-production` with
-# cancel-in-progress disabled, so a test job living inside it would queue behind
-# every production deploy. This one has its own group instead, and superseded
-# pushes cancel rather than pile up.
-#
-# The deploy workflow runs the suite again before it packages, so a red test
-# cannot reach EC2 even on a direct push to main or a manual dispatch. The
-# duplication costs a few seconds and does not depend on branch protection
-# being configured.
-#
-# The paths below are deliberately narrower than the deploy workflow's: that one
-# also watches control-nginx/**, which is reverse-proxy config and cannot change
-# the outcome of a Java test. A control-nginx-only PR therefore gets no check
-# here. It still cannot deploy untested — the deploy run executes the suite
-# itself before it packages — it just gets that signal after merge rather than
-# before. Add control-nginx/** here if that trade stops being worth it.
+# Deliberately a separate workflow from deploy-control-backend.yml.
 
 name: Test Control Backend
 

--- a/.github/workflows/test-control-backend.yml
+++ b/.github/workflows/test-control-backend.yml
@@ -1,0 +1,94 @@
+# Runs the control-backend test suite on pull requests and pushes.
+#
+# Deliberately a separate workflow from deploy-control-backend.yml. That one
+# holds a workflow-level `concurrency: control-platform-production` with
+# cancel-in-progress disabled, so a test job living inside it would queue behind
+# every production deploy. This one has its own group instead, and superseded
+# pushes cancel rather than pile up.
+#
+# The deploy workflow runs the suite again before it packages, so a red test
+# cannot reach EC2 even on a direct push to main or a manual dispatch. The
+# duplication costs a few seconds and does not depend on branch protection
+# being configured.
+#
+# The paths below are deliberately narrower than the deploy workflow's: that one
+# also watches control-nginx/**, which is reverse-proxy config and cannot change
+# the outcome of a Java test. A control-nginx-only PR therefore gets no check
+# here. It still cannot deploy untested — the deploy run executes the suite
+# itself before it packages — it just gets that signal after merge rather than
+# before. Add control-nginx/** here if that trade stops being worth it.
+
+name: Test Control Backend
+
+on:
+  pull_request:
+    paths:
+      - "control-backend/**"
+      - "map-source/**"
+      - ".github/workflows/test-control-backend.yml"
+
+  push:
+    branches:
+      - main
+      - control-docker-deployment
+    paths:
+      - "control-backend/**"
+      - "map-source/**"
+      - ".github/workflows/test-control-backend.yml"
+
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  # Keyed on the PR number where there is one, so the push and pull_request events
+  # for the same commit collapse into one run. Keying on github.ref alone would give
+  # them different groups — refs/heads/<branch> vs refs/pull/N/merge — and run the
+  # whole suite twice for every push to a branch with an open PR.
+  group: control-backend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # JDK 17 is what the pom targets. Mockito cannot instrument classes on
+      # much newer JVMs, and the failure reads as "Mockito cannot mock this
+      # class" rather than anything about the JDK.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          cache-dependency-path: control-backend/pom.xml
+
+      # Writes control-backend/src/main/resources/drop-points.json. The map
+      # tests read it straight off the classpath and DispatchFixture loads the
+      # real geometry from it, so this must run before the suite. The file is
+      # gitignored and absent from a fresh checkout.
+      - name: Stage map assets
+        run: bash map-source/stage-map-assets.sh
+
+      - name: Validate staged map assets
+        run: bash map-source/stage-map-assets.sh --check
+
+      - name: Run tests
+        working-directory: control-backend
+        run: |
+          set -Eeuo pipefail
+          mvn --batch-mode --no-transfer-progress test
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: control-backend/target/surefire-reports/
+          retention-days: 7

--- a/.github/workflows/test-control-backend.yml
+++ b/.github/workflows/test-control-backend.yml
@@ -75,3 +75,16 @@ jobs:
           name: surefire-reports
           path: control-backend/target/surefire-reports/
           retention-days: 7
+
+      # always(), not failure(): a coverage report is most wanted on a green run.
+      # JaCoCo is bound to the test phase, so the report exists by the time this
+      # step runs. Reported figure is branch coverage — see
+      # docs/control-backend-test-quality.md for why line coverage is not the
+      # number to quote.
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage
+          path: control-backend/target/site/jacoco/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ Initial development will focus on a virtual/simulated environment to validate en
 DishPatch is deployed on AWS via GitHub Actions. Deployments authenticate to AWS using IAM OIDC (no stored AWS keys).
 See [deployment.md](./docs/deployment.md) for details.
 
+## Testing
+
+The control backend has 152 tests across unit, integration and API levels, run on every pull request by
+[test-control-backend.yml](./.github/workflows/test-control-backend.yml) and again before every deployment.
+
+Measured fault detection, branch coverage, determinism and test-smell results are in
+[control-backend-test-quality.md](./docs/control-backend-test-quality.md), along with the commands to
+reproduce every figure.
+
 ## Contributing
 
 Contributions are welcome. Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.

--- a/control-backend/pom.xml
+++ b/control-backend/pom.xml
@@ -32,6 +32,16 @@
     <properties>
         <java.version>17</java.version>
         <aws.sdk.version>2.21.29</aws.sdk.version>
+
+        <!--
+            Test-quality tooling. Neither is managed by the Spring Boot parent,
+            so both are pinned here. pitest-maven and pitest-junit5-plugin must
+            be a matched pair — a mismatched junit5 plugin reports zero tests
+            found rather than failing outright.
+        -->
+        <jacoco.version>0.8.11</jacoco.version>
+        <pitest.version>1.15.3</pitest.version>
+        <pitest.junit5.version>1.2.1</pitest.junit5.version>
     </properties>
 
     <!--
@@ -144,6 +154,93 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <!--
+                Coverage. Runs as part of `mvn test`, so CI produces a report on
+                every run. Report branch coverage rather than line coverage: line
+                coverage counts a line as covered when a test merely executed it,
+                which is the weaker of the two claims and not the one worth making.
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+                Mutation testing. Deliberately bound to no lifecycle phase — PIT
+                re-runs the covering tests once per mutant, so it is run on demand:
+                    mvn test-compile org.pitest:pitest-maven:mutationCoverage
+                Report lands in target/pit-reports/.
+            -->
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>${pitest.junit5.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <targetClasses>
+                        <param>com.dishpatch.dispatch.*</param>
+                        <param>com.dishpatch.service.*</param>
+                        <param>com.dishpatch.order.*</param>
+                        <param>com.dishpatch.map.*</param>
+                    </targetClasses>
+
+                    <!--
+                        Every excluded class boots a Spring context or slice, and
+                        PIT would pay that cost once per mutant. The consequence is
+                        that the mutation score covers the service and domain layer
+                        only, not the controllers — which the report states rather
+                        than presenting the number as whole-suite.
+                    -->
+                    <excludedTestClasses>
+                        <param>com.dishpatch.ApplicationContextTest</param>
+                        <param>com.dishpatch.controller.*</param>
+                        <param>com.dishpatch.dispatch.DispatchControllerTest</param>
+                        <param>com.dishpatch.order.OrderControllerTest</param>
+                    </excludedTestClasses>
+
+                    <!--
+                        The controllers must be excluded here too, not just above.
+                        Leaving them in targetClasses while their tests are excluded
+                        reports them at 0% — not because they are untested, but
+                        because the only tests that reach them were removed from the
+                        run. That would understate the suite rather than measure it.
+                        Their coverage is the @WebMvcTest classes, reported separately.
+                    -->
+                    <excludedClasses>
+                        <param>com.dishpatch.dispatch.DispatchController</param>
+                        <param>com.dishpatch.order.OrderController</param>
+                    </excludedClasses>
+
+                    <outputFormats>
+                        <param>HTML</param>
+                        <param>XML</param>
+                    </outputFormats>
+                    <timestampedReports>false</timestampedReports>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/control-backend/src/main/java/com/dishpatch/dispatch/DispatchService.java
+++ b/control-backend/src/main/java/com/dishpatch/dispatch/DispatchService.java
@@ -149,8 +149,9 @@ public class DispatchService {
      * {@code @Autowired} is load-bearing, not decoration. A class with a single
      * constructor gets it used implicitly; add a second and Spring finds two
      * candidates, picks neither, and falls back to looking for a no-arg constructor
-     * — the context then fails to start. That failure is at startup, not compile
-     * time, so nothing catches it but running the app.
+     * — the context then fails to start. That failure is at startup rather than
+     * compile time, so it is caught by {@code ApplicationContextTest} and by
+     * nothing else in the build.
      */
     @Autowired
     public DispatchService(

--- a/control-backend/src/main/java/com/dishpatch/service/RobotService.java
+++ b/control-backend/src/main/java/com/dishpatch/service/RobotService.java
@@ -256,7 +256,8 @@ public class RobotService {
         }
     }
 
-    private boolean isFreshAt(int id, long currentTime) {
+    /** Package-private so RobotServiceTest can exercise the window without waiting 20s. */
+    boolean isFreshAt(int id, long currentTime) {
         Long lastUpdate = robotLastUpdMap.get(id);
         return lastUpdate != null && (currentTime - lastUpdate) < EXPIRY_MILLIS;
     }

--- a/control-backend/src/test/java/com/dishpatch/ApplicationContextTest.java
+++ b/control-backend/src/test/java/com/dishpatch/ApplicationContextTest.java
@@ -1,0 +1,134 @@
+package com.dishpatch;
+
+import com.dishpatch.config.CorsConfig;
+import com.dishpatch.config.WebSocketConfig;
+import com.dishpatch.controller.DynamoDbController;
+import com.dishpatch.controller.NavTestController;
+import com.dishpatch.dispatch.DispatchController;
+import com.dishpatch.dispatch.DispatchService;
+import com.dishpatch.map.DropPointService;
+import com.dishpatch.order.OrderController;
+import com.dishpatch.order.OrderRepository;
+import com.dishpatch.order.OrderService;
+import com.dishpatch.service.RobotService;
+import com.dishpatch.service.RosBridgeService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The application assembles.
+ *
+ * <p>Everything else in this suite constructs its subject with {@code new}, so
+ * nothing else here would notice a bean that cannot be built, a constructor Spring
+ * cannot choose, a {@code ${...}} placeholder with no value, or a
+ * {@code @ConditionalOnProperty} that stopped matching. Those failures happen at
+ * startup, and until this existed the only way to see one was to deploy.
+ *
+ * <p>Three beans are replaced, all of them for reaching outside the process:
+ * {@link RosBridgeService} opens a WebSocket from a {@code @PostConstruct} and
+ * retries forever, {@link DynamoDbClient} would resolve credentials, and
+ * {@link OrderRepository} scans a real table on the broadcast tick. Everything
+ * else is the real thing, which is the point — {@code DynamoDbConfig},
+ * {@code WebSocketConfig} and {@code CorsConfig} all get built for real.
+ *
+ * <p>Scheduling stays on. {@code dispatch.enabled=false} makes the dispatch tick a
+ * no-op rather than removing it, so the wiring is still exercised.
+ */
+@SpringBootTest
+@TestPropertySource(properties = {
+        // Commands real robots. Off here, but the bean is still built and scheduled.
+        "dispatch.enabled=false",
+
+        // Neutralises application.properties' `optional:file:./.env` import. An
+        // imported file outranks the document that imports it, and the flag comment
+        // in application.properties actively tells developers to put
+        // nav.test-endpoint.enabled in a local .env for bench work — without this,
+        // anyone who did would get a red suite from a cause unrelated to their
+        // change. Cleared here so the assertions below read the checked-in defaults.
+        "spring.config.import=",
+})
+class ApplicationContextTest {
+
+    @MockBean
+    private RosBridgeService rosBridgeService;
+
+    @MockBean
+    private DynamoDbClient dynamoDbClient;
+
+    @MockBean
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void theContextStarts() {
+        assertNotNull(context);
+    }
+
+    @Test
+    void everyBeanTheDispatchPipelineNeedsIsPresent() {
+        // Named individually rather than counted: a count passes when one bean is
+        // swapped for another, which is the mistake worth catching.
+        assertNotNull(context.getBean(DispatchService.class));
+        assertNotNull(context.getBean(DropPointService.class));
+        assertNotNull(context.getBean(RobotService.class));
+        assertNotNull(context.getBean(OrderService.class));
+    }
+
+    @Test
+    void theWebLayerIsWired() {
+        assertNotNull(context.getBean(DispatchController.class));
+        assertNotNull(context.getBean(OrderController.class));
+        assertNotNull(context.getBean(DynamoDbController.class));
+        assertNotNull(context.getBean(CorsConfig.class));
+        // By concrete type: Spring Boot registers a WebSocketMessageBrokerConfigurer
+        // of its own, so the interface matches two beans.
+        assertNotNull(context.getBean(WebSocketConfig.class));
+    }
+
+    @Test
+    void dispatchServiceHasExactlyOneConstructorSpringCanChoose() {
+        // Replaces DispatchAssignmentTest's reflection check with the real thing:
+        // if Spring could not pick a constructor, the context above would not have
+        // started at all. This asserts the bean it built is usable.
+        DispatchService dispatchService = context.getBean(DispatchService.class);
+
+        assertFalse(dispatchService.isEnabled(),
+                "dispatch.enabled=false should have reached the bean");
+        assertNotNull(dispatchService.assignments());
+    }
+
+    @Test
+    void theDropPointMapIsLoadedAtStartup() {
+        // @PostConstruct load() reads the staged file. A broken staging step fails
+        // the context rather than the first delivery.
+        DropPointService dropPoints = context.getBean(DropPointService.class);
+
+        assertEquals(26, dropPoints.all().size(),
+                "run map-source/stage-map-assets.sh");
+        assertTrue(dropPoints.find("counter").isPresent());
+    }
+
+    @Test
+    void theNavTestEndpointIsNotRegistered() {
+        // It is unauthenticated and it commands physical robots. The default in
+        // application.properties is false, and it has been left on in production
+        // once already, so the default is worth asserting rather than trusting.
+        assertFalse(
+                context.getBeanNamesForType(NavTestController.class).length > 0,
+                "NavTestController is registered; nav.test-endpoint.enabled is on");
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/controller/DynamoDbControllerTest.java
+++ b/control-backend/src/test/java/com/dishpatch/controller/DynamoDbControllerTest.java
@@ -1,0 +1,95 @@
+package com.dishpatch.controller;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import software.amazon.awssdk.services.dynamodb.model.TableStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The DynamoDB health probe.
+ *
+ * <p>Its value is entirely in the failure case: when orders stop appearing, this
+ * is what separates "the table is unreachable" from "there are no orders". That
+ * makes the 500 the important test — a health endpoint that reports 200 while the
+ * table is down is worse than not having one.
+ */
+@WebMvcTest(DynamoDbController.class)
+@TestPropertySource(properties = "aws.tables.orders=test-orders-table")
+class DynamoDbControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DynamoDbClient dynamoDbClient;
+
+    @Test
+    void reportsAReachableTable() throws Exception {
+        when(dynamoDbClient.describeTable(any(DescribeTableRequest.class)))
+                .thenReturn(DescribeTableResponse.builder()
+                        .table(TableDescription.builder()
+                                .tableName("test-orders-table")
+                                .tableStatus(TableStatus.ACTIVE)
+                                .build())
+                        .build());
+
+        mockMvc.perform(get("/api/dynamodb/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.connected").value(true))
+                .andExpect(jsonPath("$.table").value("test-orders-table"))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+
+        // The body above only echoes the stub, so on its own it would pass with the
+        // probe pointed anywhere. This is the assertion that pins which table was
+        // actually asked about — the failure the class exists to catch.
+        ArgumentCaptor<DescribeTableRequest> request =
+                ArgumentCaptor.forClass(DescribeTableRequest.class);
+        verify(dynamoDbClient).describeTable(request.capture());
+
+        assertEquals("test-orders-table", request.getValue().tableName());
+    }
+
+    @Test
+    void reportsAnUnreachableTableAsAServerError() throws Exception {
+        // 500 rather than 200-with-connected-false: a monitor watching status
+        // codes has to see this, not just a human reading the body.
+        when(dynamoDbClient.describeTable(any(DescribeTableRequest.class)))
+                .thenThrow(DynamoDbException.builder()
+                        .message("Requested resource not found")
+                        .build());
+
+        mockMvc.perform(get("/api/dynamodb/health"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.connected").value(false))
+                .andExpect(jsonPath("$.table").value("test-orders-table"))
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    void namesTheTableItProbedEvenWhenTheProbeFailed() throws Exception {
+        // Half of diagnosing this is finding out it was pointed at the wrong table.
+        when(dynamoDbClient.describeTable(any(DescribeTableRequest.class)))
+                .thenThrow(new RuntimeException("boom"));
+
+        mockMvc.perform(get("/api/dynamodb/health"))
+                .andExpect(jsonPath("$.table").value("test-orders-table"));
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/controller/NavTestControllerDisabledTest.java
+++ b/control-backend/src/test/java/com/dishpatch/controller/NavTestControllerDisabledTest.java
@@ -1,0 +1,70 @@
+package com.dishpatch.controller;
+
+import com.dishpatch.map.DropPointService;
+import com.dishpatch.service.RosBridgeService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The nav endpoint stays off unless someone turns it on.
+ *
+ * <p>This is a security test, not a formality. The endpoint is unauthenticated and
+ * it drives physical robots around a room with people in it, and
+ * {@code application.properties} records that it was shipped to production enabled
+ * once already despite the comment directly above the flag saying not to.
+ *
+ * <p>The guard is one {@code @ConditionalOnProperty}. Nothing else in the build
+ * notices if it is removed, mistyped, or if the default flips — every other test
+ * in the suite passes either way, and so does the deploy.
+ */
+@WebMvcTest(NavTestController.class)
+@TestPropertySource(properties = "nav.test-endpoint.enabled=false")
+class NavTestControllerDisabledTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DropPointService dropPointService;
+
+    @MockBean
+    private RosBridgeService rosBridgeService;
+
+    @Test
+    void theHealthRouteIsNotRegistered() throws Exception {
+        mockMvc.perform(get("/api/nav/health"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void theDestinationsRouteIsNotRegistered() throws Exception {
+        mockMvc.perform(get("/api/nav/destinations"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void aGoalCannotBePublishedThroughIt() throws Exception {
+        // The one that matters: no route, and nothing reaches a robot.
+        mockMvc.perform(post("/api/nav/goTo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"robotId\":1,\"destination\":\"T4\"}"))
+                .andExpect(status().isNotFound());
+
+        verify(rosBridgeService, never())
+                .publishGoal(anyInt(), anyDouble(), anyDouble(), anyDouble());
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/controller/NavTestControllerTest.java
+++ b/control-backend/src/test/java/com/dishpatch/controller/NavTestControllerTest.java
@@ -1,0 +1,164 @@
+package com.dishpatch.controller;
+
+import com.dishpatch.map.DropPointMap;
+import com.dishpatch.map.DropPointService;
+import com.dishpatch.service.RosBridgeService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The bench-testing nav endpoint, with the flag on.
+ *
+ * <p>This endpoint publishes goals straight to physical robots with no
+ * authentication in front of it. Its four outcomes are worth pinning precisely
+ * because the thing on the other end is a machine that moves: the difference
+ * between a 200 and a 502 is the difference between "a robot is now driving" and
+ * "nothing happened", and a caller that cannot tell those apart will send it twice.
+ *
+ * <p>See {@link NavTestControllerDisabledTest} for the more important half.
+ */
+@WebMvcTest(NavTestController.class)
+@TestPropertySource(properties = "nav.test-endpoint.enabled=true")
+class NavTestControllerTest {
+
+    private static final DropPointMap.DropPoint T4 =
+            new DropPointMap.DropPoint("T4", 23.226, 9.241, 0.0);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DropPointService dropPointService;
+
+    @MockBean
+    private RosBridgeService rosBridgeService;
+
+    @BeforeEach
+    void setUp() {
+        when(rosBridgeService.isConnected()).thenReturn(true);
+
+        // Everything is unknown except T4, so the 404 path needs no per-test setup.
+        when(dropPointService.find(anyString())).thenReturn(Optional.empty());
+        when(dropPointService.find("T4")).thenReturn(Optional.of(T4));
+    }
+
+    private static String goal(String destination) {
+        return "{\"robotId\":1,\"destination\":\"" + destination + "\"}";
+    }
+
+    // ── the read-only endpoints ──────────────────────────────────────────────
+
+    @Test
+    void reportsTheFleetLinkAndHowManyDestinationsLoaded() throws Exception {
+        when(rosBridgeService.followedRobotIds()).thenReturn(List.of(1, 2));
+        when(dropPointService.all()).thenReturn(List.of(T4));
+
+        mockMvc.perform(get("/api/nav/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rosbridgeConnected").value(true))
+                .andExpect(jsonPath("$.robots[0]").value(1))
+                .andExpect(jsonPath("$.robots[1]").value(2))
+                .andExpect(jsonPath("$.destinationsLoaded").value(1));
+    }
+
+    @Test
+    void listsDestinationsWithTheirPoses() throws Exception {
+        when(dropPointService.frameId()).thenReturn("map");
+        when(dropPointService.all()).thenReturn(List.of(T4));
+
+        mockMvc.perform(get("/api/nav/destinations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.frameId").value("map"))
+                .andExpect(jsonPath("$.count").value(1))
+                .andExpect(jsonPath("$.destinations[0].id").value("T4"))
+                .andExpect(jsonPath("$.destinations[0].x").value(23.226))
+                .andExpect(jsonPath("$.destinations[0].y").value(9.241))
+                .andExpect(jsonPath("$.destinations[0].yaw").value(0.0));
+    }
+
+    // ── sending a robot ──────────────────────────────────────────────────────
+
+    @Test
+    void publishesTheResolvedPose() throws Exception {
+        mockMvc.perform(post("/api/nav/goTo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(goal("T4")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sent").value(true))
+                .andExpect(jsonPath("$.robotId").value(1))
+                .andExpect(jsonPath("$.destination").value("T4"))
+                .andExpect(jsonPath("$.x").value(23.226))
+                .andExpect(jsonPath("$.y").value(9.241));
+
+        // The map lookup is the part that can silently go wrong: a goal published
+        // at the wrong coordinates still returns 200.
+        verify(rosBridgeService).publishGoal(1, 23.226, 9.241, 0.0);
+    }
+
+    @Test
+    void reportsAnUnknownDestinationAsNotFound() throws Exception {
+        mockMvc.perform(post("/api/nav/goTo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(goal("T99")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.sent").value(false))
+                .andExpect(jsonPath("$.error").value("Unknown destination: T99"));
+
+        verify(rosBridgeService, never())
+                .publishGoal(anyInt(), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void refusesWhenRosbridgeIsDown() throws Exception {
+        when(rosBridgeService.isConnected()).thenReturn(false);
+
+        mockMvc.perform(post("/api/nav/goTo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(goal("T4")))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.sent").value(false))
+                .andExpect(jsonPath("$.error").value("rosbridge not connected"));
+
+        verify(rosBridgeService, never())
+                .publishGoal(anyInt(), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void reportsAFailedPublishAsABadGateway() throws Exception {
+        // Distinct from 503 on purpose: the link was up and the write still failed,
+        // so retrying is reasonable in a way it is not for a disconnected bridge.
+        Mockito.doThrow(new IllegalStateException("send limit exceeded"))
+                .when(rosBridgeService)
+                .publishGoal(anyInt(), anyDouble(), anyDouble(), anyDouble());
+
+        mockMvc.perform(post("/api/nav/goTo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(goal("T4")))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.sent").value(false))
+                .andExpect(jsonPath("$.error")
+                        .value("Failed to publish goal: send limit exceeded"));
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/dispatch/DispatchAssignmentTest.java
+++ b/control-backend/src/test/java/com/dishpatch/dispatch/DispatchAssignmentTest.java
@@ -164,25 +164,4 @@ class DispatchAssignmentTest {
                 fixture.assignmentFor("o-1").orElseThrow().state());
         assertEquals(List.of("T6", "counter"), fixture.destinationsSentTo(1));
     }
-
-    @Test
-    void keepsExactlyOneConstructorForSpringToPick() {
-        // The second constructor exists so tests can supply a clock, and it costs the
-        // class its implicit constructor selection: with more than one, Spring picks
-        // whichever carries @Autowired, and with none it hunts for a no-arg
-        // constructor and fails to start the context.
-        //
-        // That failure happens at startup, not compile time, so nothing else in this
-        // build would catch it — and the only way to see it for real is to boot the
-        // app, which connects to the live rosbridge and starts commanding robots.
-        // This assertion is the cheap version of that check.
-        long annotated = java.util.Arrays
-                .stream(DispatchService.class.getDeclaredConstructors())
-                .filter(constructor -> constructor.isAnnotationPresent(
-                        org.springframework.beans.factory.annotation.Autowired.class))
-                .count();
-
-        assertEquals(1, annotated,
-                "exactly one constructor must carry @Autowired or the app will not start");
-    }
 }

--- a/control-backend/src/test/java/com/dishpatch/dispatch/DispatchControllerTest.java
+++ b/control-backend/src/test/java/com/dishpatch/dispatch/DispatchControllerTest.java
@@ -1,0 +1,184 @@
+package com.dishpatch.dispatch;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The diagnostic endpoint's wire format.
+ *
+ * <p>{@code /api/dispatch} exists to answer "why is nothing being delivered" when
+ * the robot stream cannot tell no-orders apart from rosbridge-down. That makes the
+ * field names the whole product: a renamed field does not break the build, it
+ * breaks the one tool available during an incident.
+ *
+ * <p>A real request through Spring's dispatcher and real Jackson serialisation,
+ * with the service beneath mocked — so this pins the JSON, not the logic.
+ */
+@WebMvcTest(DispatchController.class)
+class DispatchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DispatchService dispatchService;
+
+    /** A pipeline with nothing in flight. */
+    private void idlePipeline() {
+        when(dispatchService.isEnabled()).thenReturn(true);
+        when(dispatchService.isRosbridgeConnected()).thenReturn(true);
+        when(dispatchService.millisSinceLastTick()).thenReturn(250L);
+        when(dispatchService.queuedOrders()).thenReturn(0);
+        when(dispatchService.freeRobotIds()).thenReturn(List.of(1, 2));
+        when(dispatchService.assignments()).thenReturn(List.of());
+        when(dispatchService.skipped()).thenReturn(Map.of());
+    }
+
+    @Test
+    void reportsAnIdlePipeline() throws Exception {
+        idlePipeline();
+
+        mockMvc.perform(get("/api/dispatch"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.rosbridgeConnected").value(true))
+                .andExpect(jsonPath("$.millisSinceLastTick").value(250))
+                .andExpect(jsonPath("$.queuedOrders").value(0))
+                .andExpect(jsonPath("$.freeRobots[0]").value(1))
+                .andExpect(jsonPath("$.freeRobots[1]").value(2))
+                .andExpect(jsonPath("$.active").isEmpty())
+                .andExpect(jsonPath("$.skipped").isEmpty());
+    }
+
+    @Test
+    void reportsADeliveryInFlightWithEveryFieldTheDashboardReads() throws Exception {
+        idlePipeline();
+
+        DispatchAssignment assignment = new DispatchAssignment(
+                "o-1", 3, "T6", DispatchState.TO_TABLE, 0L, 2, 0L);
+
+        when(dispatchService.assignments()).thenReturn(List.of(assignment));
+        when(dispatchService.millisRemaining(any())).thenReturn(0L);
+        when(dispatchService.metresToGo(any())).thenReturn(4.25);
+        when(dispatchService.isNavigating(anyInt())).thenReturn(true);
+        when(dispatchService.isRobotStale(anyInt())).thenReturn(false);
+        when(dispatchService.hasGoalFailed(anyInt())).thenReturn(false);
+
+        mockMvc.perform(get("/api/dispatch"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active[0].orderId").value("o-1"))
+                .andExpect(jsonPath("$.active[0].robotId").value(3))
+                .andExpect(jsonPath("$.active[0].destination").value("T6"))
+                .andExpect(jsonPath("$.active[0].millisRemaining").value(0))
+                .andExpect(jsonPath("$.active[0].metresToGo").value(4.25))
+                .andExpect(jsonPath("$.active[0].navigating").value(true))
+                .andExpect(jsonPath("$.active[0].robotStale").value(false))
+                .andExpect(jsonPath("$.active[0].attempts").value(2))
+                .andExpect(jsonPath("$.active[0].goalFailed").value(false));
+    }
+
+    @Test
+    void wiresEachDiagnosticBooleanToItsOwnSource() throws Exception {
+        // navigating, robotStale and goalFailed are three same-typed arguments in a
+        // ten-argument record constructor, and an incident is diagnosed by reading
+        // them against each other. Exercised one-hot, because false is Mockito's
+        // default for a boolean: with all three false, transposing any pair — or
+        // hardcoding one — passes without a murmur.
+        idlePipeline();
+        when(dispatchService.assignments()).thenReturn(List.of(
+                new DispatchAssignment("o-1", 3, "T6", DispatchState.TO_TABLE, 0L, 1, 0L)));
+
+        boolean[][] oneHot = {
+                { true, false, false },
+                { false, true, false },
+                { false, false, true },
+        };
+
+        for (boolean[] flags : oneHot) {
+            when(dispatchService.isNavigating(anyInt())).thenReturn(flags[0]);
+            when(dispatchService.isRobotStale(anyInt())).thenReturn(flags[1]);
+            when(dispatchService.hasGoalFailed(anyInt())).thenReturn(flags[2]);
+
+            mockMvc.perform(get("/api/dispatch"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.active[0].navigating").value(flags[0]))
+                    .andExpect(jsonPath("$.active[0].robotStale").value(flags[1]))
+                    .andExpect(jsonPath("$.active[0].goalFailed").value(flags[2]));
+        }
+    }
+
+    @Test
+    void serialisesTheStageAsItsName() throws Exception {
+        // The frontend switches on this string. Jackson's default for an enum is
+        // the constant name, and nothing else pins it.
+        idlePipeline();
+        when(dispatchService.assignments()).thenReturn(List.of(
+                new DispatchAssignment("o-1", 3, "T6", DispatchState.AT_TABLE, 0L, 1, 0L)));
+
+        mockMvc.perform(get("/api/dispatch"))
+                .andExpect(jsonPath("$.active[0].state").value("AT_TABLE"));
+    }
+
+    @Test
+    void neverLeaksTheAbsoluteDeadline() throws Exception {
+        // deadlineMillis is internal and unreadable without date maths; the view
+        // reports time remaining instead. Documented, so worth enforcing.
+        idlePipeline();
+        when(dispatchService.assignments()).thenReturn(List.of(
+                new DispatchAssignment("o-1", 3, "T6", DispatchState.TO_TABLE,
+                        1_760_000_000_000L, 1, 0L)));
+
+        mockMvc.perform(get("/api/dispatch"))
+                .andExpect(jsonPath("$.active[0].deadlineMillis").doesNotExist())
+                .andExpect(jsonPath("$.active[0].goalPublishedAtMillis").doesNotExist());
+    }
+
+    @Test
+    void reportsSkippedOrdersAsAListRatherThanAMap() throws Exception {
+        idlePipeline();
+        when(dispatchService.skipped())
+                .thenReturn(Map.of("o-9", "Unknown destination: T99"));
+
+        mockMvc.perform(get("/api/dispatch"))
+                .andExpect(jsonPath("$.skipped[0].orderId").value("o-9"))
+                .andExpect(jsonPath("$.skipped[0].reason")
+                        .value("Unknown destination: T99"));
+    }
+
+    @Test
+    void reportsTheSentinelBeforeTheFirstTick() throws Exception {
+        // -1 rather than 0: zero would read as "ticked just now", which is the
+        // opposite of what it means and the first thing to check in an incident.
+        idlePipeline();
+        when(dispatchService.millisSinceLastTick()).thenReturn(-1L);
+
+        mockMvc.perform(get("/api/dispatch"))
+                .andExpect(jsonPath("$.millisSinceLastTick").value(-1));
+    }
+
+    @Test
+    void answersTheControlFrontendsOrigin() throws Exception {
+        // CorsConfig is a WebMvcConfigurer, so the slice picks it up. Without the
+        // allowed origin the dashboard gets a CORS error rather than data.
+        idlePipeline();
+
+        mockMvc.perform(get("/api/dispatch").header("Origin", "http://localhost:5173"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin",
+                        "http://localhost:5173"));
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/dispatch/DispatchFixture.java
+++ b/control-backend/src/test/java/com/dishpatch/dispatch/DispatchFixture.java
@@ -105,13 +105,20 @@ final class DispatchFixture {
     private final List<RobotUpdate> robotUpdates = new ArrayList<>();
 
     /**
-     * Everything the pipeline has logged this JVM, and where this fixture came in.
+     * What the pipeline has logged on this thread, and where this fixture came in.
      * <p>
-     * Shared and installed once: the logger is keyed on the class name, so a handler
-     * per fixture would pile up across the suite and every one of them would also
-     * receive the next test's records.
+     * The handler is installed once: the logger is keyed on the class name, so a
+     * handler per fixture would pile up across the suite and every one of them would
+     * also receive the next test's records.
+     * <p>
+     * What it writes to is per-thread. A single shared list is correct only while
+     * surefire runs one test at a time — turn on parallel execution and
+     * {@link #warnings()} starts reading records logged by a concurrent fixture,
+     * which fails in the confusing direction: tests pass because someone else's
+     * warning happened to be there.
      */
-    private static final List<LogRecord> LOG_RECORDS = new ArrayList<>();
+    private static final ThreadLocal<List<LogRecord>> LOG_RECORDS =
+            ThreadLocal.withInitial(ArrayList::new);
     private static boolean logHandlerInstalled;
     private final int logMark;
 
@@ -270,13 +277,13 @@ final class DispatchFixture {
 
     /** Warnings the pipeline logged. A recovery that says nothing is half a recovery. */
     List<String> warnings() {
-        synchronized (LOG_RECORDS) {
-            return LOG_RECORDS.subList(logMark, LOG_RECORDS.size()).stream()
-                    .filter(record -> record.getLevel().intValue()
-                            >= Level.WARNING.intValue())
-                    .map(LogRecord::getMessage)
-                    .collect(Collectors.toList());
-        }
+        List<LogRecord> records = LOG_RECORDS.get();
+
+        return records.subList(logMark, records.size()).stream()
+                .filter(record -> record.getLevel().intValue()
+                        >= Level.WARNING.intValue())
+                .map(LogRecord::getMessage)
+                .collect(Collectors.toList());
     }
 
     /** Current status of an order, as DynamoDB would hold it. */
@@ -414,9 +421,10 @@ final class DispatchFixture {
             Logger.getLogger(DispatchService.class.getName()).addHandler(new Handler() {
                 @Override
                 public void publish(LogRecord record) {
-                    synchronized (LOG_RECORDS) {
-                        LOG_RECORDS.add(record);
-                    }
+                    // Filed against whichever thread logged it. The pipeline logs
+                    // from inside tick(), which these tests call themselves, so a
+                    // record always lands on the list of the test that caused it.
+                    LOG_RECORDS.get().add(record);
                 }
 
                 @Override
@@ -428,8 +436,6 @@ final class DispatchFixture {
             logHandlerInstalled = true;
         }
 
-        synchronized (LOG_RECORDS) {
-            return LOG_RECORDS.size();
-        }
+        return LOG_RECORDS.get().size();
     }
 }

--- a/control-backend/src/test/java/com/dishpatch/order/DynamoDbValueMapperTest.java
+++ b/control-backend/src/test/java/com/dishpatch/order/DynamoDbValueMapperTest.java
@@ -1,0 +1,197 @@
+package com.dishpatch.order;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Translation from DynamoDB's tagged values to the plain maps the API returns.
+ *
+ * <p>Every order the control frontend and the dispatcher ever see passes through
+ * here. The mapper is total by design — an unrecognised value becomes null rather
+ * than throwing — which is the right call for a scan over a table the POS writes,
+ * and also the reason a mistake here is invisible: a mistranslated field arrives
+ * as a missing field, and the order simply looks incomplete.
+ *
+ * <p>In this package because the mapper is package-private.
+ */
+class DynamoDbValueMapperTest {
+
+    private static Map<String, Object> map(String key, AttributeValue value) {
+        return DynamoDbValueMapper.toJavaMap(Map.of(key, value));
+    }
+
+    private static Object value(AttributeValue attributeValue) {
+        return map("k", attributeValue).get("k");
+    }
+
+    // ── scalars ──────────────────────────────────────────────────────────────
+
+    @Test
+    void readsAString() {
+        assertEquals("order-1", value(AttributeValue.builder().s("order-1").build()));
+    }
+
+    @Test
+    void readsANumberAsBigDecimal() {
+        // BigDecimal rather than double: order totals are money, and the frontend
+        // renders whatever precision is stored.
+        Object result = value(AttributeValue.builder().n("42.50").build());
+
+        assertInstanceOf(BigDecimal.class, result);
+        assertEquals(new BigDecimal("42.50"), result);
+    }
+
+    @Test
+    void keepsAMalformedNumberAsItsRawString() {
+        // A number attribute that will not parse is data we still want to surface,
+        // not an exception mid-scan that loses every other order in the page.
+        assertEquals("not-a-number",
+                value(AttributeValue.builder().n("not-a-number").build()));
+    }
+
+    @Test
+    void readsABoolean() {
+        assertEquals(true, value(AttributeValue.builder().bool(true).build()));
+        assertEquals(false, value(AttributeValue.builder().bool(false).build()));
+    }
+
+    @Test
+    void readsAnExplicitNull() {
+        assertNull(value(AttributeValue.builder().nul(true).build()));
+    }
+
+    @Test
+    void readsBinaryAsBase64() {
+        AttributeValue binary = AttributeValue.builder()
+                .b(SdkBytes.fromString("hi", StandardCharsets.UTF_8))
+                .build();
+
+        assertEquals("aGk=", value(binary));
+    }
+
+    // ── nested shapes ────────────────────────────────────────────────────────
+
+    @Test
+    void readsANestedMap() {
+        // The shape OrderService.normalizeOrder flattens: orders carry their table
+        // as a nested object written by the POS.
+        AttributeValue table = AttributeValue.builder()
+                .m(Map.of(
+                        "tableNo", AttributeValue.builder().s("T6").build(),
+                        "seats", AttributeValue.builder().n("4").build()))
+                .build();
+
+        Object result = value(table);
+
+        assertInstanceOf(Map.class, result);
+        Map<?, ?> nested = (Map<?, ?>) result;
+        assertEquals("T6", nested.get("tableNo"));
+        assertEquals(new BigDecimal("4"), nested.get("seats"));
+    }
+
+    @Test
+    void readsAListOfMixedTypes() {
+        AttributeValue items = AttributeValue.builder()
+                .l(List.of(
+                        AttributeValue.builder().s("Laksa").build(),
+                        AttributeValue.builder().n("2").build(),
+                        AttributeValue.builder().bool(true).build()))
+                .build();
+
+        assertEquals(List.of("Laksa", new BigDecimal("2"), true), value(items));
+    }
+
+    @Test
+    void readsDeeplyNestedStructures() {
+        // Order items are a list of maps, so the recursion has to hold two levels
+        // down, not just one.
+        AttributeValue orderItems = AttributeValue.builder()
+                .l(List.of(AttributeValue.builder()
+                        .m(Map.of("name", AttributeValue.builder().s("Laksa").build()))
+                        .build()))
+                .build();
+
+        List<?> items = (List<?>) value(orderItems);
+        Map<?, ?> first = (Map<?, ?>) items.get(0);
+
+        assertEquals("Laksa", first.get("name"));
+    }
+
+    @Test
+    void readsAStringSet() {
+        Object result = value(AttributeValue.builder().ss("a", "b").build());
+
+        assertInstanceOf(List.class, result);
+        assertTrue(((List<?>) result).containsAll(List.of("a", "b")));
+    }
+
+    @Test
+    void readsANumberSet() {
+        Object result = value(AttributeValue.builder().ns("1", "2").build());
+
+        assertEquals(List.of(new BigDecimal("1"), new BigDecimal("2")), result);
+    }
+
+    // ── the whole item ───────────────────────────────────────────────────────
+
+    @Test
+    void mapsAnEmptyItemToAnEmptyMap() {
+        assertEquals(Map.of(), DynamoDbValueMapper.toJavaMap(Map.of()));
+    }
+
+    @Test
+    void anAttributeWithNothingSetBecomesNull() {
+        // Not reachable from a well-formed table, but the mapper's final fallthrough
+        // is what stops an unknown future type from throwing mid-scan.
+        assertNull(value(AttributeValue.builder().build()));
+    }
+
+    @Test
+    void keepsTheOrderOfTheItemsKeys() {
+        // LinkedHashMap, not HashMap: the JSON the frontend receives should not
+        // reshuffle its fields between requests.
+        Map<String, AttributeValue> item = new LinkedHashMap<>();
+        item.put("orderId", AttributeValue.builder().s("o-1").build());
+        item.put("orderDate", AttributeValue.builder().s("2026-08-11").build());
+        item.put("orderStatus", AttributeValue.builder().s("Preparing").build());
+
+        assertEquals(
+                new ArrayList<>(item.keySet()),
+                new ArrayList<>(DynamoDbValueMapper.toJavaMap(item).keySet()));
+    }
+
+    @Test
+    void mapsAnOrderShapedItemWhole() {
+        Map<String, AttributeValue> item = new LinkedHashMap<>();
+        item.put("orderId", AttributeValue.builder().s("o-1").build());
+        item.put("orderStatus", AttributeValue.builder().s("Preparing").build());
+        item.put("total", AttributeValue.builder().n("18.90").build());
+        item.put("paid", AttributeValue.builder().bool(false).build());
+        item.put("note", AttributeValue.builder().nul(true).build());
+        item.put("table", AttributeValue.builder()
+                .m(Map.of("tableNo", AttributeValue.builder().s("T6").build()))
+                .build());
+
+        Map<String, Object> order = DynamoDbValueMapper.toJavaMap(item);
+
+        assertEquals("o-1", order.get("orderId"));
+        assertEquals("Preparing", order.get("orderStatus"));
+        assertEquals(new BigDecimal("18.90"), order.get("total"));
+        assertEquals(false, order.get("paid"));
+        assertNull(order.get("note"));
+        assertEquals("T6", ((Map<?, ?>) order.get("table")).get("tableNo"));
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/order/OrderControllerTest.java
+++ b/control-backend/src/test/java/com/dishpatch/order/OrderControllerTest.java
@@ -1,0 +1,177 @@
+package com.dishpatch.order;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The orders API as the POS and the control frontend call it.
+ *
+ * <p>Two things are pinned here that no other test can reach. The
+ * {@code ApiResponse} envelope — {@code success}, {@code message}, {@code data} —
+ * is what every caller unwraps, and it exists only in this controller. And the
+ * rejection paths: {@code OrderStatus.fromValue} throws from inside Jackson, so
+ * whether a bad status is a 400 or a 500 is decided by Spring's error handling
+ * rather than by any code we wrote, and it has never been checked.
+ */
+@WebMvcTest(OrderController.class)
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrderService orderService;
+
+    private static Map<String, Object> order(String id, String status) {
+        return Map.of("orderId", id, "orderStatus", status, "status", status);
+    }
+
+    // ── reading ──────────────────────────────────────────────────────────────
+
+    @Test
+    void listsOrdersInsideTheEnvelope() throws Exception {
+        when(orderService.getOrders())
+                .thenReturn(List.of(order("o-1", "Preparing")));
+
+        mockMvc.perform(get("/api/orders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].orderId").value("o-1"))
+                .andExpect(jsonPath("$.data[0].orderStatus").value("Preparing"));
+    }
+
+    @Test
+    void anEmptyTableIsStillASuccess() throws Exception {
+        // Not a 404: no orders is a normal state, and the dashboard renders it.
+        when(orderService.getOrders()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/orders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void returnsOneOrder() throws Exception {
+        when(orderService.getOrder("o-1"))
+                .thenReturn(Optional.of(order("o-1", "Preparing")));
+
+        mockMvc.perform(get("/api/orders/o-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderId").value("o-1"));
+    }
+
+    @Test
+    void reportsAnUnknownOrderAsNotFound() throws Exception {
+        when(orderService.getOrder("nope")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/orders/nope"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Order not found"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    // ── updating ─────────────────────────────────────────────────────────────
+
+    @Test
+    void updatesAnOrdersStatus() throws Exception {
+        when(orderService.updateStatus("o-1", OrderStatus.COMPLETED))
+                .thenReturn(Optional.of(order("o-1", "Completed")));
+
+        mockMvc.perform(put("/api/orders/o-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"orderStatus\":\"Completed\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Order updated"))
+                .andExpect(jsonPath("$.data.orderStatus").value("Completed"));
+    }
+
+    @Test
+    void acceptsALowercaseStatus() throws Exception {
+        // fromValue is deliberately case-insensitive; this is the path that proves
+        // the leniency survives Jackson rather than only holding in a unit test.
+        when(orderService.updateStatus("o-1", OrderStatus.CANCELLED))
+                .thenReturn(Optional.of(order("o-1", "Cancelled")));
+
+        mockMvc.perform(put("/api/orders/o-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"orderStatus\":\"cancelled\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void reportsAnUpdateToAMissingOrderAsNotFound() throws Exception {
+        when(orderService.updateStatus(anyString(), any()))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/orders/nope")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"orderStatus\":\"Completed\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Order not found"));
+    }
+
+    // ── what it rejects ──────────────────────────────────────────────────────
+
+    @Test
+    void rejectsAnUnknownStatusAsABadRequest() throws Exception {
+        // fromValue throws IllegalArgumentException from inside deserialization.
+        // Unhandled that surfaces as a 500, which would tell the caller the server
+        // is broken rather than that they sent a bad value.
+        mockMvc.perform(put("/api/orders/o-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"orderStatus\":\"Delivered\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(orderService, never()).updateStatus(anyString(), any());
+    }
+
+    @Test
+    void rejectsAMissingStatus() throws Exception {
+        // @NotNull on the record component, via @Valid.
+        mockMvc.perform(put("/api/orders/o-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+
+        verify(orderService, never()).updateStatus(anyString(), any());
+    }
+
+    @Test
+    void rejectsANullStatus() throws Exception {
+        mockMvc.perform(put("/api/orders/o-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"orderStatus\":null}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void rejectsMalformedJson() throws Exception {
+        mockMvc.perform(put("/api/orders/o-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{not json"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/order/OrderServiceTest.java
+++ b/control-backend/src/test/java/com/dishpatch/order/OrderServiceTest.java
@@ -1,0 +1,222 @@
+package com.dishpatch.order;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The shape an order has by the time anything else sees it.
+ *
+ * <p>{@code normalizeOrder} is a contract with two consumers that cannot see each
+ * other. The control frontend reads {@code status} and {@code createdAt}, which do
+ * not exist in DynamoDB and are invented here; {@code DispatchService} reads
+ * {@code tableNo}, which the POS writes as a nested object. Rename or drop one of
+ * these and nothing fails to compile — an order simply stops being deliverable, or
+ * renders blank.
+ */
+class OrderServiceTest {
+
+    private OrderRepository orderRepository;
+    private SimpMessagingTemplate messagingTemplate;
+    private OrderService orderService;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository = Mockito.mock(OrderRepository.class);
+        messagingTemplate = Mockito.mock(SimpMessagingTemplate.class);
+        orderService = new OrderService(orderRepository, messagingTemplate);
+    }
+
+    /** An order as DynamoDB holds it, before normalising. */
+    private static Map<String, Object> stored(Object... keysAndValues) {
+        Map<String, Object> order = new LinkedHashMap<>();
+
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            order.put(String.valueOf(keysAndValues[i]), keysAndValues[i + 1]);
+        }
+
+        return order;
+    }
+
+    private Map<String, Object> normalisedFrom(Map<String, Object> storedOrder) {
+        Mockito.when(orderRepository.findAll()).thenReturn(List.of(storedOrder));
+        return orderService.getOrders().get(0);
+    }
+
+    // ── the status field ─────────────────────────────────────────────────────
+
+    @Test
+    void defaultsAMissingStatusToPreparing() {
+        // An order the POS wrote without a status is still owed to a table, so it
+        // has to enter the dispatch queue rather than being ignored.
+        Map<String, Object> order = normalisedFrom(stored("orderId", "o-1"));
+
+        assertEquals("Preparing", order.get("orderStatus"));
+        assertEquals("Preparing", order.get("status"));
+    }
+
+    @Test
+    void keepsAStatusThatIsAlreadySet() {
+        Map<String, Object> order =
+                normalisedFrom(stored("orderId", "o-1", "orderStatus", "Completed"));
+
+        assertEquals("Completed", order.get("orderStatus"));
+    }
+
+    @Test
+    void addsTheStatusAliasTheFrontendReads() {
+        Map<String, Object> order =
+                normalisedFrom(stored("orderId", "o-1", "orderStatus", "Cancelled"));
+
+        assertEquals(order.get("orderStatus"), order.get("status"),
+                "the alias must not drift from the field it aliases");
+    }
+
+    @Test
+    void addsCreatedAtFromOrderDate() {
+        Map<String, Object> order = normalisedFrom(
+                stored("orderId", "o-1", "orderDate", "2026-08-11T05:49:00Z"));
+
+        assertEquals("2026-08-11T05:49:00Z", order.get("createdAt"));
+    }
+
+    // ── the table ────────────────────────────────────────────────────────────
+
+    @Test
+    void flattensTheNestedTableThePosWrites() {
+        // This is the field DispatchService routes on. A nested object left
+        // unflattened makes every order undeliverable.
+        Map<String, Object> order = normalisedFrom(stored(
+                "orderId", "o-1",
+                "table", Map.of("tableNo", "T6", "seats", 4)));
+
+        assertEquals("T6", order.get("tableNo"));
+    }
+
+    @Test
+    void passesAScalarTableStraightThrough() {
+        Map<String, Object> order =
+                normalisedFrom(stored("orderId", "o-1", "table", "T9"));
+
+        assertEquals("T9", order.get("tableNo"));
+    }
+
+    @Test
+    void leavesTableNoNullWhenThereIsNoTable() {
+        // Not an error here — DispatchService skips it with "Order has no table",
+        // which is a reportable state rather than a crash.
+        Map<String, Object> order = normalisedFrom(stored("orderId", "o-1"));
+
+        assertTrue(order.containsKey("tableNo"));
+        assertNull(order.get("tableNo"));
+    }
+
+    // ── the list ─────────────────────────────────────────────────────────────
+
+    @Test
+    void returnsNewestFirst() {
+        Mockito.when(orderRepository.findAll()).thenReturn(List.of(
+                stored("orderId", "middle", "orderDate", "2026-08-11T05:30:00Z"),
+                stored("orderId", "oldest", "orderDate", "2026-08-11T05:00:00Z"),
+                stored("orderId", "newest", "orderDate", "2026-08-11T06:00:00Z")));
+
+        assertEquals(List.of("newest", "middle", "oldest"),
+                orderService.getOrders().stream().map(o -> o.get("orderId")).toList());
+    }
+
+    @Test
+    void sortsAnOrderWithNoDateLast() {
+        Mockito.when(orderRepository.findAll()).thenReturn(List.of(
+                stored("orderId", "undated"),
+                stored("orderId", "dated", "orderDate", "2026-08-11T05:00:00Z")));
+
+        assertEquals(List.of("dated", "undated"),
+                orderService.getOrders().stream().map(o -> o.get("orderId")).toList());
+    }
+
+    @Test
+    void doesNotMutateWhatTheRepositoryReturned() {
+        // normalizeOrder copies. Writing the aliases into the repository's own map
+        // would mean a second read saw a different shape than the first.
+        Map<String, Object> storedOrder = stored("orderId", "o-1");
+        Mockito.when(orderRepository.findAll()).thenReturn(List.of(storedOrder));
+
+        orderService.getOrders();
+
+        assertEquals(Map.of("orderId", "o-1"), storedOrder);
+    }
+
+    // ── single order and update ──────────────────────────────────────────────
+
+    @Test
+    void normalisesASingleOrderToo() {
+        Mockito.when(orderRepository.findById("o-1"))
+                .thenReturn(Optional.of(stored("orderId", "o-1", "table", "T3")));
+
+        assertEquals("T3", orderService.getOrder("o-1").orElseThrow().get("tableNo"));
+    }
+
+    @Test
+    void isEmptyForAnUnknownOrder() {
+        Mockito.when(orderRepository.findById("nope")).thenReturn(Optional.empty());
+
+        assertTrue(orderService.getOrder("nope").isEmpty());
+    }
+
+    @Test
+    void normalisesTheOrderReturnedByAnUpdate() {
+        Mockito.when(orderRepository.updateStatus("o-1", OrderStatus.COMPLETED))
+                .thenReturn(Optional.of(
+                        stored("orderId", "o-1", "orderStatus", "Completed",
+                                "orderDate", "2026-08-11T05:00:00Z")));
+
+        Map<String, Object> updated =
+                orderService.updateStatus("o-1", OrderStatus.COMPLETED).orElseThrow();
+
+        assertEquals("Completed", updated.get("status"));
+        assertEquals("2026-08-11T05:00:00Z", updated.get("createdAt"));
+    }
+
+    @Test
+    void isEmptyWhenTheOrderToUpdateIsGone() {
+        Mockito.when(orderRepository.updateStatus("nope", OrderStatus.COMPLETED))
+                .thenReturn(Optional.empty());
+
+        assertTrue(orderService.updateStatus("nope", OrderStatus.COMPLETED).isEmpty());
+    }
+
+    // ── the broadcast ────────────────────────────────────────────────────────
+
+    @Test
+    void pushesTheOrderListToTheFrontend() {
+        Mockito.when(orderRepository.findAll())
+                .thenReturn(List.of(stored("orderId", "o-1")));
+
+        orderService.broadcastOrders();
+
+        Mockito.verify(messagingTemplate)
+                .convertAndSend(Mockito.eq("/topic/orders"), Mockito.<Object>any());
+    }
+
+    @Test
+    void aFailedBroadcastDoesNotKillTheScheduler() {
+        // Thrown out of a @Scheduled method this would stop the fixed-delay loop
+        // for the life of the process, and the frontend's order list would freeze
+        // with no error anywhere.
+        Mockito.when(orderRepository.findAll())
+                .thenThrow(new RuntimeException("DynamoDB is having a moment"));
+
+        assertDoesNotThrow(() -> orderService.broadcastOrders());
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/order/OrderStatusTest.java
+++ b/control-backend/src/test/java/com/dishpatch/order/OrderStatusTest.java
@@ -1,0 +1,113 @@
+package com.dishpatch.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The order status contract, on both sides of the wire.
+ *
+ * <p>{@link OrderStatus#fromValue} is a {@code @JsonCreator}, so it sits directly
+ * on the API boundary: it decides whether {@code PUT /api/orders/{id}} is a 200 or
+ * a 400, and it is reached by request bodies rather than by our own code. The
+ * {@code @JsonValue} side is the string DynamoDB and the control frontend both
+ * store and read, so the exact casing is a contract with two other systems.
+ */
+class OrderStatusTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // ── the stored form ──────────────────────────────────────────────────────
+
+    @Test
+    void serialisesAsTheCapitalisedWordBothOtherSystemsExpect() {
+        assertEquals("Preparing", OrderStatus.PREPARING.getValue());
+        assertEquals("Completed", OrderStatus.COMPLETED.getValue());
+        assertEquals("Cancelled", OrderStatus.CANCELLED.getValue());
+    }
+
+    @Test
+    void jacksonWritesTheValueRatherThanTheEnumName() throws Exception {
+        // Without @JsonValue this would serialise as "PREPARING" and every order
+        // written by the backend would disagree with every order written by the POS.
+        assertEquals("\"Preparing\"",
+                objectMapper.writeValueAsString(OrderStatus.PREPARING));
+    }
+
+    @Test
+    void roundTripsThroughJson() throws Exception {
+        for (OrderStatus status : OrderStatus.values()) {
+            String json = objectMapper.writeValueAsString(status);
+            assertEquals(status, objectMapper.readValue(json, OrderStatus.class));
+        }
+    }
+
+    // ── parsing what arrives ─────────────────────────────────────────────────
+
+    @Test
+    void acceptsTheExactValue() {
+        assertEquals(OrderStatus.PREPARING, OrderStatus.fromValue("Preparing"));
+        assertEquals(OrderStatus.COMPLETED, OrderStatus.fromValue("Completed"));
+        assertEquals(OrderStatus.CANCELLED, OrderStatus.fromValue("Cancelled"));
+    }
+
+    @Test
+    void acceptsAnyCasing() {
+        // Deliberate leniency: the POS and the control frontend have both sent
+        // lowercase at different times.
+        assertEquals(OrderStatus.PREPARING, OrderStatus.fromValue("preparing"));
+        assertEquals(OrderStatus.COMPLETED, OrderStatus.fromValue("COMPLETED"));
+        assertEquals(OrderStatus.CANCELLED, OrderStatus.fromValue("cAnCeLlEd"));
+    }
+
+    @Test
+    void acceptsTheEnumNameToo() {
+        assertEquals(OrderStatus.PREPARING, OrderStatus.fromValue("PREPARING"));
+    }
+
+    @Test
+    void parsesFromJsonThroughTheCreator() throws Exception {
+        assertEquals(OrderStatus.COMPLETED,
+                objectMapper.readValue("\"Completed\"", OrderStatus.class));
+        assertEquals(OrderStatus.COMPLETED,
+                objectMapper.readValue("\"completed\"", OrderStatus.class));
+    }
+
+    // ── what it refuses ──────────────────────────────────────────────────────
+
+    @Test
+    void rejectsNull() {
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class, () -> OrderStatus.fromValue(null));
+
+        assertTrue(thrown.getMessage().contains("required"), thrown.getMessage());
+    }
+
+    @Test
+    void rejectsBlank() {
+        assertThrows(IllegalArgumentException.class, () -> OrderStatus.fromValue(""));
+        assertThrows(IllegalArgumentException.class, () -> OrderStatus.fromValue("   "));
+    }
+
+    @Test
+    void rejectsAnUnknownStatusAndSaysWhatIsAllowed() {
+        // The message reaches the caller as the body of a 400, so it has to be
+        // useful to whoever sent the request.
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class, () -> OrderStatus.fromValue("Delivered"));
+
+        assertTrue(thrown.getMessage().contains("Preparing"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("Completed"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("Cancelled"), thrown.getMessage());
+    }
+
+    @Test
+    void doesNotMatchOnAPrefix() {
+        // "Prep" is not Preparing. Substring matching here would silently accept
+        // typos and write a status nothing else recognises.
+        assertThrows(IllegalArgumentException.class, () -> OrderStatus.fromValue("Prep"));
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/service/RobotServiceTest.java
+++ b/control-backend/src/test/java/com/dishpatch/service/RobotServiceTest.java
@@ -1,0 +1,227 @@
+package com.dishpatch.service;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Telemetry in, and the two questions the dispatcher asks of it.
+ *
+ * <p>{@code DispatchService} treats this class as its source of truth for where a
+ * robot is and whether it is still alive, and every dispatch test stubs both. The
+ * real implementations are here: position comes out of a RobotStatus message, and
+ * liveness is a 20-second window since the last one.
+ *
+ * <p>The freshness window is the load-bearing half. A robot wrongly judged fresh
+ * is handed an order it will never deliver; wrongly judged stale, it drops out of
+ * the fleet. {@code isFreshAt} takes the current time as an argument, so the
+ * boundary is exercised here rather than waited out.
+ *
+ * <p>{@code messagingTemplate} is field-injected, so a bare {@code new
+ * RobotService()} leaves it null and every path through {@code broadcast()} would
+ * NPE. Set reflectively rather than changing the class — constructor injection
+ * would be the better fix, and is a separate change.
+ */
+class RobotServiceTest {
+
+    /** The expiry the class enforces. A literal, so shortening it fails here. */
+    private static final long EXPIRY_MILLIS = 20_000L;
+
+    private RobotService service;
+    private SimpMessagingTemplate messagingTemplate;
+
+    @BeforeEach
+    void setUp() {
+        service = new RobotService();
+        messagingTemplate = Mockito.mock(SimpMessagingTemplate.class);
+        ReflectionTestUtils.setField(service, "messagingTemplate", messagingTemplate);
+    }
+
+    /** A RobotStatus message as rosbridge delivers it. */
+    private static JsonObject status(double x, double y, double z, double w) {
+        return JsonParser.parseString("""
+                {
+                  "battery": 82,
+                  "speed": 0.35,
+                  "pose": {
+                    "position": { "x": %s, "y": %s, "z": 0.0 },
+                    "orientation": { "x": 0.0, "y": 0.0, "z": %s, "w": %s }
+                  }
+                }
+                """.formatted(x, y, z, w)).getAsJsonObject();
+    }
+
+    private static JsonObject statusAt(double x, double y) {
+        return status(x, y, 0.0, 1.0);
+    }
+
+    // ── telemetry in ─────────────────────────────────────────────────────────
+
+    @Test
+    void createsARobotTheFirstTimeItReports() {
+        service.updateField(7, "status", statusAt(1.0, 2.0));
+
+        assertEquals(List.of(7),
+                service.getAllRobots().stream().map(r -> r.getId()).toList());
+        assertEquals("Robot 7", service.getAllRobots().get(0).getName());
+    }
+
+    @Test
+    void readsThePositionTheDispatcherMeasuresDistancesFrom() {
+        service.updateField(1, "status", statusAt(18.128, 9.241));
+
+        RobotService.Position position = service.getPosition(1).orElseThrow();
+
+        assertEquals(18.128, position.x());
+        assertEquals(9.241, position.y());
+    }
+
+    @Test
+    void hasNoPositionForARobotThatHasNeverReported() {
+        assertTrue(service.getPosition(99).isEmpty());
+    }
+
+    @Test
+    void recoversHeadingFromTheQuaternion() {
+        // The fleet is planar, so yaw = 2*atan2(z, w) is exact. A quarter turn is
+        // z = sin(pi/4), w = cos(pi/4).
+        double halfAngle = Math.PI / 4;
+        service.updateField(1, "status",
+                status(0.0, 0.0, Math.sin(halfAngle), Math.cos(halfAngle)));
+
+        assertEquals(Math.PI / 2, service.getAllRobots().get(0).getYaw(), 1e-9);
+    }
+
+    @Test
+    void readsBatteryAndSpeed() {
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+
+        assertEquals(82, service.getAllRobots().get(0).getBattery());
+        assertEquals(0.35f, service.getAllRobots().get(0).getSpeed(), 1e-6);
+    }
+
+    @Test
+    void aLaterReportMovesTheSameRobotRatherThanAddingOne() {
+        service.updateField(1, "status", statusAt(1.0, 1.0));
+        service.updateField(1, "status", statusAt(5.0, 6.0));
+
+        assertEquals(1, service.getAllRobots().size());
+        assertEquals(5.0, service.getPosition(1).orElseThrow().x());
+    }
+
+    // ── the freshness window ─────────────────────────────────────────────────
+
+    @Test
+    void aRobotIsFreshRightAfterItReports() {
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+
+        assertTrue(service.isFresh(1));
+        assertEquals(List.of(1), service.getFreshRobotIds());
+    }
+
+    @Test
+    void aRobotThatHasNeverReportedIsNotFresh() {
+        // Distinct from stale: there is no timestamp at all. A null here must not
+        // read as "updated at epoch zero" or as fresh.
+        assertFalse(service.isFresh(99));
+        assertFalse(service.isFreshAt(99, System.currentTimeMillis()));
+        assertTrue(service.getFreshRobotIds().isEmpty());
+    }
+
+    @Test
+    void staysFreshUntilTheWindowIsUp() {
+        long before = System.currentTimeMillis();
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+        long after = System.currentTimeMillis();
+
+        // The stamp lies somewhere in [before, after], so bracketing keeps this
+        // exact without controlling the clock.
+        assertTrue(service.isFreshAt(1, after),
+                "fresh the moment it reported");
+        assertTrue(service.isFreshAt(1, before + EXPIRY_MILLIS - 1_000),
+                "still fresh a second short of the window");
+    }
+
+    @Test
+    void goesStaleOnceTheWindowPasses() {
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+        long after = System.currentTimeMillis();
+
+        assertFalse(service.isFreshAt(1, after + EXPIRY_MILLIS),
+                "the window is exclusive at its far end");
+        assertFalse(service.isFreshAt(1, after + EXPIRY_MILLIS + 60_000));
+    }
+
+    @Test
+    void listsEveryRobotInsideTheWindow() {
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+        service.updateField(2, "status", statusAt(1.0, 1.0));
+        long after = System.currentTimeMillis();
+
+        assertEquals(List.of(1, 2), service.getFreshRobotIds(),
+                "both reported just now");
+
+        // And neither survives the window. getFreshRobotIds reads the wall clock
+        // itself, so the expiry is checked through isFreshAt.
+        assertFalse(service.isFreshAt(1, after + EXPIRY_MILLIS));
+        assertFalse(service.isFreshAt(2, after + EXPIRY_MILLIS));
+    }
+
+    // ── what the dispatcher writes back ──────────────────────────────────────
+
+    @Test
+    void recordsAnAssignment() {
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+
+        service.setAssignment(1, RobotService.STATUS_SERVING, "T6", "o-1");
+
+        var robot = service.getAllRobots().get(0);
+        assertEquals(RobotService.STATUS_SERVING, robot.getStatus());
+        assertEquals("T6", robot.getDestination());
+        assertEquals("o-1", robot.getOrderId());
+    }
+
+    @Test
+    void ignoresAnAssignmentForARobotThatHasNotReported() {
+        // The dispatcher can name a robot the graph knows about but that has sent
+        // no telemetry yet. That must not invent one.
+        service.setAssignment(42, RobotService.STATUS_SERVING, "T6", "o-1");
+
+        assertTrue(service.getAllRobots().isEmpty());
+    }
+
+    // ── the frontend push ────────────────────────────────────────────────────
+
+    @Test
+    void pushesToTheFrontendOnEveryUpdate() {
+        // The map goes blank when these stop, which is how #68 first showed itself.
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+
+        Mockito.verify(messagingTemplate)
+                .convertAndSend(Mockito.eq("/topic/robot-locations"), Mockito.<Object>any());
+        Mockito.verify(messagingTemplate)
+                .convertAndSend(Mockito.eq("/topic/robot-stats"), Mockito.<Object>any());
+    }
+
+    @Test
+    void countsTheFleetByStatusForTheDashboard() {
+        service.updateField(1, "status", statusAt(0.0, 0.0));
+        service.updateField(2, "status", statusAt(1.0, 1.0));
+        service.setAssignment(1, RobotService.STATUS_SERVING, "T6", "o-1");
+
+        assertEquals(1L, service.getStats().get("serving"));
+        assertEquals(1L, service.getStats().get("waiting"),
+                "robot 2 is still on the status it was created with");
+        assertEquals(2, service.getStats().get("total"));
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/service/RosBridgeNavStatusTest.java
+++ b/control-backend/src/test/java/com/dishpatch/service/RosBridgeNavStatusTest.java
@@ -1,0 +1,221 @@
+package com.dishpatch.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How {@link RosBridgeService} reads Nav2's action status topic.
+ *
+ * <p>This is the seam the dispatch package cannot see. Every test in
+ * {@code DispatchFixture} stubs {@code isNavigating} and {@code lastGoalFailed}
+ * with a boolean the test chose, so all 27 of them encode our <em>belief</em>
+ * about what Nav2 reports rather than what it reports. If the parsing below is
+ * wrong, the entire dispatch suite still passes and the fleet still stops. The
+ * 2026-08-11 stall arrived through exactly this gap.
+ *
+ * <p>Driven through {@code handleTextMessage} with real rosbridge frames, so
+ * these assert the wire format rather than a Java method call. No session is
+ * needed: the nav-status branch returns before anything is sent, and before
+ * {@code robotService} — which is field-injected and null here — is touched.
+ *
+ * <p>Status values are {@code action_msgs/msg/GoalStatus}.
+ */
+class RosBridgeNavStatusTest {
+
+    private static final int ACCEPTED = 1;
+    private static final int EXECUTING = 2;
+    private static final int CANCELING = 3;
+    private static final int SUCCEEDED = 4;
+    private static final int CANCELED = 5;
+    private static final int ABORTED = 6;
+
+    private RosBridgeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RosBridgeService();
+    }
+
+    /** A publish frame on a robot's navigate_to_pose status topic. */
+    private void navStatus(int robotId, int... statuses) {
+        StringBuilder list = new StringBuilder();
+
+        for (int i = 0; i < statuses.length; i++) {
+            if (i > 0) {
+                list.append(",");
+            }
+            // goal_info is carried by the real message and ignored by the parser;
+            // including it keeps these frames honest about what arrives.
+            list.append("{\"goal_info\":{\"goal_id\":{\"uuid\":[").append(i)
+                    .append("]},\"stamp\":{\"sec\":0,\"nanosec\":0}},\"status\":")
+                    .append(statuses[i]).append("}");
+        }
+
+        receive("{\"op\":\"publish\",\"topic\":\"/robot" + robotId
+                + "/navigate_to_pose/_action/status\","
+                + "\"msg\":{\"status_list\":[" + list + "]}}");
+    }
+
+    private void receive(String payload) {
+        service.handleTextMessage(null, new TextMessage(payload));
+    }
+
+    // ── nothing heard yet ────────────────────────────────────────────────────
+
+    @Test
+    void reportsNeitherLiveNorFailedBeforeAnyStatusArrives() {
+        // The dispatcher reads both on its first tick, before Nav2 has said
+        // anything. Neither may read as true, or a fresh robot looks like it is
+        // already driving, or like its goal already failed.
+        assertFalse(service.isNavigating(1));
+        assertFalse(service.lastGoalFailed(1));
+    }
+
+    @Test
+    void anEmptyStatusListMeansNav2HoldsNothing() {
+        navStatus(1);
+
+        assertFalse(service.isNavigating(1));
+        assertFalse(service.lastGoalFailed(1));
+    }
+
+    // ── a goal in flight ─────────────────────────────────────────────────────
+
+    @Test
+    void anAcceptedGoalIsLive() {
+        navStatus(1, ACCEPTED);
+
+        assertTrue(service.isNavigating(1),
+                "an accepted goal is one the dispatcher must not preempt");
+    }
+
+    @Test
+    void anExecutingGoalIsLive() {
+        navStatus(1, EXECUTING);
+
+        assertTrue(service.isNavigating(1));
+    }
+
+    @Test
+    void aCancelingGoalIsNotLive() {
+        // CANCELING is not in the accepted/executing pair, so the robot is not
+        // considered to be driving. Worth pinning: it is the one non-terminal
+        // status that reads as idle.
+        navStatus(1, CANCELING);
+
+        assertFalse(service.isNavigating(1));
+    }
+
+    // ── goals that ended ─────────────────────────────────────────────────────
+
+    @Test
+    void aSucceededGoalIsNeitherLiveNorFailed() {
+        navStatus(1, SUCCEEDED);
+
+        assertFalse(service.isNavigating(1));
+        assertFalse(service.lastGoalFailed(1),
+                "arriving is not a failure; treating it as one re-sends a goal "
+                        + "at a robot that already got there");
+    }
+
+    @Test
+    void anAbortedGoalIsTheFailureThatStrandedTheFleet() {
+        // 2026-08-11: Nav2 aborted the goal milliseconds after accepting it. This
+        // pair of booleans is the entire signal DispatchService recovers from.
+        navStatus(1, ABORTED);
+
+        assertFalse(service.isNavigating(1));
+        assertTrue(service.lastGoalFailed(1));
+    }
+
+    @Test
+    void aCancelledGoalCountsAsFailed() {
+        navStatus(1, CANCELED);
+
+        assertFalse(service.isNavigating(1));
+        assertTrue(service.lastGoalFailed(1));
+    }
+
+    // ── the retained array ───────────────────────────────────────────────────
+
+    @Test
+    void readsTheLastEntryAsTheNewest() {
+        // Nav2 retains terminal goals and appends, so the array is a history and
+        // only its tail is current. An earlier abort must not outlive the goal
+        // that came after it — the dispatcher would give up on a live delivery.
+        navStatus(1, ABORTED, ACCEPTED);
+
+        assertTrue(service.isNavigating(1));
+        assertFalse(service.lastGoalFailed(1),
+                "the abort is history; the newest goal was accepted");
+    }
+
+    @Test
+    void staysLiveWhileAnyGoalIsActiveEvenIfTheNewestFailed() {
+        // The two fields answer different questions and can disagree: something is
+        // still executing, while the most recent entry is a failure. This is why
+        // lastGoalFailed is documented as meaningful only when isNavigating is
+        // false, and the pairing is worth pinning rather than assuming.
+        navStatus(1, ACCEPTED, ABORTED);
+
+        assertTrue(service.isNavigating(1));
+        assertTrue(service.lastGoalFailed(1));
+    }
+
+    @Test
+    void handlesAnArrayOfNothingButRetainedTerminalGoals() {
+        // What the topic looks like after a busy spell — the shape that grew past
+        // the 8 KB receive buffer in #68.
+        navStatus(1, SUCCEEDED, SUCCEEDED, ABORTED, SUCCEEDED);
+
+        assertFalse(service.isNavigating(1));
+        assertFalse(service.lastGoalFailed(1),
+                "the newest goal succeeded, whatever happened earlier");
+    }
+
+    // ── more than one robot ──────────────────────────────────────────────────
+
+    @Test
+    void tracksEachRobotSeparately() {
+        navStatus(1, ABORTED);
+        navStatus(2, EXECUTING);
+
+        assertFalse(service.isNavigating(1));
+        assertTrue(service.lastGoalFailed(1));
+
+        assertTrue(service.isNavigating(2));
+        assertFalse(service.lastGoalFailed(2));
+    }
+
+    @Test
+    void aLaterFrameReplacesTheEarlierVerdict() {
+        navStatus(1, EXECUTING);
+        assertTrue(service.isNavigating(1));
+
+        navStatus(1, ABORTED);
+
+        assertFalse(service.isNavigating(1),
+                "the robot stopped driving; a stale true here freezes the delivery");
+        assertTrue(service.lastGoalFailed(1));
+    }
+
+    // ── bad input ────────────────────────────────────────────────────────────
+
+    @Test
+    void aMalformedFrameIsSwallowedAndLeavesTheVerdictAlone() {
+        // handleTextMessage catches and logs. What matters is that a junk frame
+        // cannot flip a robot's state — the rosbridge link carries whatever the
+        // graph publishes, and one bad message must not strand a delivery.
+        navStatus(1, EXECUTING);
+
+        receive("{\"op\":\"publish\",\"topic\":\"/robot1"
+                + "/navigate_to_pose/_action/status\",\"msg\":{}}");
+
+        assertTrue(service.isNavigating(1),
+                "the last good frame should still stand");
+    }
+}

--- a/control-backend/src/test/java/com/dishpatch/service/RosBridgeServiceTest.java
+++ b/control-backend/src/test/java/com/dishpatch/service/RosBridgeServiceTest.java
@@ -1,7 +1,9 @@
 package com.dishpatch.service;
 
+import jakarta.websocket.WebSocketContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
@@ -11,6 +13,8 @@ import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,6 +87,34 @@ class RosBridgeServiceTest {
             }
             return true;
         });
+    }
+
+    /**
+     * #68: the client's container defaulted to an 8 KB text buffer, and Nav2's
+     * retained goal-status array grew past it under load. Every connection then
+     * died on the first frame it received and reconnected straight into the same
+     * failure, which blanked the frontend and stranded a robot in RETURNING.
+     * <p>
+     * The fix is one line in {@code createClient}, it has no other test, and
+     * removing it would look harmless in review.
+     */
+    @Test
+    void raisesTheReceiveBufferWellPastNav2sRetainedStatusArray() {
+        // Read off the client the service will actually dial with, not a container
+        // built alongside it. The wiring is half the fix: ContainerProvider hands out
+        // a fresh 8 KB container per call, so a createClient() that dropped the
+        // argument would be straight back in #68 while a freshly built container
+        // still measured 1 MB. StandardWebSocketClient exposes no getter, hence the
+        // reflection — a Spring field rename fails this loudly rather than quietly
+        // passing.
+        Object client = ReflectionTestUtils.getField(new RosBridgeService(), "client");
+        WebSocketContainer container = (WebSocketContainer)
+                ReflectionTestUtils.getField(client, "webSocketContainer");
+
+        // Compared against a literal rather than MAX_TEXT_MESSAGE_BYTES: reading the
+        // constant back would pass no matter what it was changed to.
+        assertTrue(container.getDefaultMaxTextMessageBufferSize() >= 1024 * 1024,
+                "text buffer is back near the 8 KB default that caused #68");
     }
 
     @Test
@@ -189,11 +221,17 @@ class RosBridgeServiceTest {
     @Test
     void keepsRetryingUntilTheHandshakeSucceeds() throws Exception {
         AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch thirdAttempt = new CountDownLatch(3);
+        CountDownLatch fourthAttempt = new CountDownLatch(4);
 
         RosBridgeService retrying = new RosBridgeService() {
             @Override
             protected CompletableFuture<WebSocketSession> openSession() {
-                if (attempts.incrementAndGet() < 3) {
+                int attempt = attempts.incrementAndGet();
+                thirdAttempt.countDown();
+                fourthAttempt.countDown();
+
+                if (attempt < 3) {
                     return CompletableFuture.failedFuture(new ConnectException("refused"));
                 }
                 return CompletableFuture.completedFuture(session);
@@ -203,40 +241,51 @@ class RosBridgeServiceTest {
 
         retrying.connect();
 
-        long deadline = System.currentTimeMillis() + 2000;
-        while (attempts.get() < 3 && System.currentTimeMillis() < deadline) {
-            Thread.sleep(5);
-        }
-
-        assertEquals(3, attempts.get(),
-                "should have retried past the refused connections");
+        // Waits for the third dial rather than for a fixed stretch of time, so a
+        // loaded CI runner makes this slower rather than red.
+        assertTrue(thirdAttempt.await(5, TimeUnit.SECONDS),
+                "should have retried past the refused connections; saw "
+                        + attempts.get() + " attempt(s)");
 
         // And stops once connected, rather than reconnecting over a live session.
-        Thread.sleep(50);
-        assertEquals(3, attempts.get(), "kept dialing after the handshake succeeded");
+        // A fourth dial would be due 5ms after the third, so 200ms of silence is
+        // a 40x margin on the answer being "it stopped".
+        assertFalse(fourthAttempt.await(200, TimeUnit.MILLISECONDS),
+                "kept dialing after the handshake succeeded");
     }
 
     /** One close does not start a second retry loop on top of the running one. */
     @Test
     void doesNotStackRetryLoops() throws Exception {
         AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch firstAttempt = new CountDownLatch(1);
+        CountDownLatch secondAttempt = new CountDownLatch(2);
 
         RosBridgeService retrying = new RosBridgeService() {
             @Override
             protected CompletableFuture<WebSocketSession> openSession() {
                 attempts.incrementAndGet();
+                firstAttempt.countDown();
+                secondAttempt.countDown();
                 return CompletableFuture.failedFuture(new ConnectException("refused"));
             }
         };
-        retrying.setRetryDelayMs(1000);
+        retrying.setRetryDelayMs(5_000);
 
         retrying.connect();
+
+        assertTrue(firstAttempt.await(5, TimeUnit.SECONDS),
+                "the first loop never dialled at all");
+
         retrying.afterConnectionClosed(session, CloseStatus.SESSION_NOT_RELIABLE);
         retrying.connect();
 
-        Thread.sleep(100);
-
-        assertEquals(1, attempts.get(),
-                "each connect() started its own loop; they will race for the session");
+        // A loop dials before it sleeps, so a second one would land within
+        // microseconds — 500ms is an enormous margin for detecting it. The window
+        // only has to stay under the 5s retry delay to avoid mistaking the first
+        // loop's own second dial for a stacked one.
+        assertFalse(secondAttempt.await(500, TimeUnit.MILLISECONDS),
+                "a second retry loop started dialling; the two will race for the session");
+        assertEquals(1, attempts.get());
     }
 }

--- a/docs/control-backend-test-quality.md
+++ b/docs/control-backend-test-quality.md
@@ -1,0 +1,318 @@
+# Control Backend — Test Quality Report
+
+This document is evidence for a single claim: **the control-backend test suite would
+notice if the code broke.** Test count and line coverage cannot support that claim, so
+they are not what is reported here.
+
+> **Scope:** `control-backend` only. Measurements were taken on JDK 17 at commit
+> `b75556a`. Code quality (static analysis, style checking) is out of scope for this
+> document.
+
+---
+
+## 1. Method
+
+Five independent measurements, because each proves something different and none is
+sufficient alone:
+
+| Measurement | What it proves | What it cannot prove |
+|:--|:--|:--|
+| Mutation score | Tests detect injected faults | Anything about code the tests never reach |
+| Branch coverage | Decision paths are exercised | That anything was *asserted* |
+| Determinism | Results are trustworthy | That the assertions are meaningful |
+| Smell audit | Known anti-patterns are absent | That the tests are correct |
+| Traceability | Tests answer real defects | That coverage is complete |
+
+Sections 7 and 8 are the substantive ones. A number can be produced by any project;
+what distinguishes this suite is that it was attacked deliberately, and the results of
+those attacks — including the ones that exposed our own bad tests — are reported.
+
+---
+
+## 2. Suite overview
+
+**152 tests, green in ~7 seconds**, across three levels.
+
+| Rung | Scope | Files | Tests |
+|:--|:--|--:|--:|
+| 1 — Unit | One class, collaborators mocked | 11 | 115 |
+| 2 — Integration | Real Spring context, out-of-process beans mocked | 1 | 6 |
+| 3 — Component / API | Real HTTP through Spring's dispatcher, services mocked | 5 | 31 |
+
+The distribution is deliberately pyramid-shaped: the slowest and most brittle level is
+the smallest. Total runtime matters as a quality property in its own right — a suite
+that takes minutes stops being run before every change.
+
+Full file-level breakdown is in the project's PR description; the ladder is summarised
+here to establish that the levels were chosen rather than accumulated.
+
+---
+
+## 3. Mutation score (primary evidence)
+
+Measured with PIT. It injects faults into the source — inverting conditionals, altering
+boundaries, removing calls — then re-runs the suite and reports how many the tests
+caught.
+
+```
+321 mutations generated
+207 killed                    64%  mutation score
+ 58 with no test coverage
+                              79%  test strength
+```
+
+**Two numbers, because they answer different questions.** *Mutation score* (64%) is
+kills over all mutants, including those in code no test reaches. *Test strength* (79%)
+is kills over only the mutants the tests actually reach — it measures the quality of the
+tests we have, separately from the question of what is untested.
+
+Runtime: 41 seconds.
+
+### Scope of this measurement
+
+PIT re-runs the covering tests once per mutant, so anything that boots a Spring context
+is prohibitively slow. `ApplicationContextTest` and all five `@WebMvcTest` classes are
+excluded from the run, and the two controller classes they cover are excluded from the
+target set as well — leaving them targeted while their only tests are excluded would
+report them at 0% and understate the suite rather than measure it.
+
+**This score therefore covers the service and domain layer, not the controllers.** The
+controllers are covered by the rung-3 tests reported in section 2.
+
+### By class
+
+| Class | Mutants | Killed | No coverage | Score |
+|:--|--:|--:|--:|--:|
+| `DynamoDbValueMapper` | 21 | 21 | 0 | **100%** |
+| `OrderStatus` | 8 | 8 | 0 | **100%** |
+| `OrderService` | 8 | 8 | 0 | **100%** |
+| `DropPointService` | 4 | 4 | 0 | **100%** |
+| `DispatchAssignment` | 3 | 3 | 0 | **100%** |
+| `RosBridgeService` | 68 | 42 | 8 | 61% |
+| `DispatchService` | 128 | 78 | 25 | 60% |
+| `RobotService` | 71 | 39 | 15 | 54% |
+| `OrderRepository` | 10 | 0 | 10 | **0%** |
+
+The five classes at 100% are the ones covered by pure unit tests written against a known
+contract. `OrderRepository` at 0% is the known, deliberate gap — its condition
+expressions and pagination loop cannot be tested with mocks and need DynamoDB Local,
+which is scheduled work rather than an oversight (section 9).
+
+### What the run found that we did not know
+
+The most useful output was not the score. Grouping surviving mutants by operator:
+
+| Mutation operator | Survived | Generated |
+|:--|--:|--:|
+| `ConditionalsBoundaryMutator` | 10 | 13 |
+| `BooleanTrueReturnValsMutator` | 17 | 27 |
+| `VoidMethodCallMutator` | 29 | 74 |
+| `MathMutator` | 9 | 20 |
+
+**Boundary mutations survive at 77%.** This codebase is built on thresholds — a grace
+window, an attempt cap, an arrival radius, a 20-second freshness window — so this is the
+weakest point in the suite and the clearest direction for the next round of work. Two
+concrete examples:
+
+- **`RosBridgeService.publishGoal:529-530`** — `Math.sin(yaw / 2.0)` and
+  `Math.cos(yaw / 2.0)`, the outgoing quaternion conversion. PIT replaced division with
+  multiplication and **no test noticed**. Every navigation goal would be published with
+  a wrong heading. The suite tests the *inverse* conversion
+  (`RobotServiceTest.recoversHeadingFromTheQuaternion`, quaternion → yaw on incoming
+  telemetry) but never yaw → quaternion on outgoing goals.
+- **`DispatchService.hasArrived:578`** — `distance <= ARRIVAL_RADIUS_M`. Nothing
+  exercises a robot at exactly the arrival radius, so the boundary is unpinned.
+
+Neither gap was visible in coverage, and neither was caught by code review. This is the
+argument for mutation testing, made on our own code.
+
+---
+
+## 4. Branch coverage
+
+Measured with JaCoCo, produced on every CI run and uploaded as a build artifact.
+
+| Counter | Covered | Total | % |
+|:--|--:|--:|--:|
+| **Branch** | 202 | 289 | **69.9%** |
+| Line | 728 | 891 | 81.7% |
+| Instruction | 3220 | 3780 | 85.2% |
+
+**Branch coverage is the figure quoted**, not line coverage. A line counts as covered
+when a test merely executes it; a branch requires both outcomes of a decision to be
+taken. Quoting 81.7% when 69.9% is the better-founded number would overstate the result.
+
+| Package | Branch | Line |
+|:--|--:|--:|
+| `controller` | 100% | 100% |
+| `map` | 100% | 100% |
+| `dispatch` | 77.1% | 87.8% |
+| `order` | 69.6% | 65.4% |
+| `service` | 63.4% | 81.6% |
+| `config` | 50.0% | 78.8% |
+| `utils` | — | 0% |
+
+`utils` (`SSLUtils`) has no tests at all. `order` is depressed by `OrderRepository`, the
+same gap as in section 3.
+
+**Coverage is reported as a supporting metric, not as evidence of test quality.** Section
+7 documents a case in this repository where a test had full line coverage of the method
+it guarded and detected nothing.
+
+---
+
+## 5. Determinism
+
+The suite was run **30 consecutive times**: **30 passed, 0 failed.**
+
+Flake-inducing constructs, verified by search across the whole test tree:
+
+| Construct | Count |
+|:--|--:|
+| `Thread.sleep` | **0** |
+| `@Disabled` / `@Ignore` | **0** |
+| Empty `catch` blocks | **0** |
+
+`Thread.sleep` was previously present in two rosbridge retry tests. Both were rewritten
+to wait on a `CountDownLatch`, so a slow CI runner makes them slower rather than red.
+`DispatchService`'s time-dependent behaviour is tested through an injected `Clock`, which
+is why a suite covering 20-second timeouts and multi-minute recovery sequences completes
+in 7 seconds.
+
+Rerun-on-failure (`-Dsurefire.rerunFailingTestsCount`) is deliberately **not** configured.
+It hides flakiness rather than measuring it.
+
+---
+
+## 6. Test smell audit
+
+Audited manually against the test-smell catalogue (van Deursen et al., 2001). A manual
+audit is used in preference to a tool because the interesting result is the reasoning
+about an accepted smell, not a count.
+
+| Smell | Present | Evidence / decision |
+|:--|:--|:--|
+| Assertion-free test | No | 152 `@Test` methods scanned, 0 without an assertion |
+| Sleepy Test | No | 0 occurrences of `Thread.sleep`; both former cases converted to latches |
+| Mystery Guest | **Yes — accepted** | See below |
+| Eager Test | Marginal | Median 2 assertions per test (min 1, max 10); the max is a deliberate field-by-field JSON contract check |
+| Assertion Roulette | No | Assertions carry explanatory messages throughout |
+| Conditional Test Logic | No | The only loops are a one-hot matrix and fixture helpers, not branching assertions |
+| Ignored Test | No | 0 `@Disabled` |
+
+### The accepted smell
+
+`DropPointServiceTest` and `DispatchFixture` read `drop-points.json` from the classpath —
+a real file generated by `map-source/stage-map-assets.sh`. This is textbook **Mystery
+Guest**: the tests depend on external state, and fail if the staging step has not run.
+
+It is kept deliberately. Guarding that staging pipeline is one of the test's purposes —
+the file is gitignored and generated, so a broken staging step should fail the build
+loudly rather than surface as a robot driving to the wrong table. Using invented
+coordinates instead would make the distance assertions in `DispatchRecoveryTest`
+meaningless, since they compare real drop points against a real floor plan.
+
+The cost is a documented prerequisite, stated in the reproduction steps in section 10.
+
+---
+
+## 7. Targeted mutation experiments
+
+Four faults were introduced by hand and the suite observed. These predate the automated
+PIT run and were the reason for commissioning it.
+
+| # | Fault introduced | Result |
+|:--|:--|:--|
+| 1 | Removed `GOAL_ABORTED` from `RosBridgeService.lastGoalFailed` | All 26 dispatch tests stayed green. Caught only by `RosBridgeNavStatusTest` (4 failures) |
+| 2 | `new StandardWebSocketClient()` — reinstating the #68 8 KB buffer | **All 8 rosbridge tests stayed green** |
+| 3 | Hardcoded a wrong table name in `DynamoDbController.health()` | **All 3 tests stayed green** |
+| 4 | Transposed `robotStale` / `goalFailed` in `DispatchController` | **All 7 tests stayed green** |
+
+### Experiment 1 — the case for the test
+
+The dispatch package stubs `isNavigating()` and `lastGoalFailed()` in every one of its 26
+tests, so all of them encode our *belief* about Nav2's semantics rather than the parser's
+behaviour. Inverting that parser leaves the entire dispatch suite green.
+`RosBridgeNavStatusTest` was written specifically to close that seam, and it is the only
+thing that catches the fault. This is the seam the 2026-08-11 outage came through.
+
+### Experiments 2–4 — the case against our own tests
+
+The remaining three exposed defects **in the tests**, not the code. Experiment 2 is the
+most instructive: the #68 guard asserted on a `WebSocketContainer` it constructed itself
+rather than the one the service dials with. Because `ContainerProvider` returns a fresh
+container per call, the test measured 1 MB and passed while the service ran on the 8 KB
+default that caused the original incident.
+
+**That test had full line coverage of the method it guarded and a fault-detection rate of
+zero.** It is the clearest available demonstration that coverage and test quality are
+different properties.
+
+All four faults are now detected. Each fix was verified by re-planting the fault and
+confirming a red suite before reverting.
+
+---
+
+## 8. Adversarial review of the test suite
+
+The suite was reviewed by three independent agents with distinct remits — CI
+configuration, test rigour, and production-code safety — instructed to find tests that
+could not fail.
+
+**Seven findings, five confirmed real, three verified by mutation.** Two were tests that
+provably could not fail (experiments 3 and 4 above). All five were fixed before merge.
+
+The review also rejected several plausible-sounding concerns after verification — the
+`System.currentTimeMillis()` bracketing in `RobotServiceTest` was checked and found sound
+in both directions, and the `ThreadLocal` log capture in `DispatchFixture` was confirmed
+correct. Reporting what the review *cleared* matters as much as what it caught.
+
+---
+
+## 9. Limitations
+
+Stated so the figures above are not read as broader than they are.
+
+- **The mutation score excludes the controllers** (section 3). It measures the service
+  and domain layer.
+- **`OrderRepository` is untested** — 0% mutation score, and the main drag on `order`
+  package coverage. Its condition expressions and scan pagination cannot be tested with
+  mocks; this needs DynamoDB Local or Testcontainers, which is planned work.
+- **`SSLUtils` has no tests** — 0% line coverage.
+- **Boundary conditions are the weakest area**, at 77% mutant survival for boundary
+  mutations. Two specific gaps are named in section 3.
+- **No end-to-end tests exist.** Nothing exercises the full chain from order to delivered
+  meal; the highest level reached is a single deployable driven over HTTP.
+- **Coverage figures include only `control-backend`.**
+
+---
+
+## 10. Reproduction
+
+All figures in this document are reproducible from a clean checkout. **JDK 17 is
+required** — Mockito cannot instrument classes on much newer JVMs, and the resulting
+error names Mockito rather than the JDK.
+
+```bash
+# Prerequisite: stage the generated map assets (gitignored, see section 6)
+./map-source/stage-map-assets.sh
+```
+
+```bash
+# Suite + branch coverage -> control-backend/target/site/jacoco/index.html
+cd control-backend && JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn --batch-mode test
+```
+
+```bash
+# Mutation score -> control-backend/target/pit-reports/index.html  (~41s)
+cd control-backend && JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn --batch-mode test-compile org.pitest:pitest-maven:mutationCoverage
+```
+
+```bash
+# Determinism: 30 consecutive runs, expect 30/30
+cd control-backend && for i in $(seq 1 30); do JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -q --batch-mode -Djacoco.skip=true test || echo "FAILED run $i"; done
+```
+
+Coverage is produced on every CI run and uploaded as the `jacoco-coverage` artifact by
+[`.github/workflows/test-control-backend.yml`](../.github/workflows/test-control-backend.yml).
+PIT is run on demand — at roughly 41 seconds it is too slow to gate a pull request.


### PR DESCRIPTION
## Test suite structure

| Rung | Files | Tests |
|:--|--:|--:|
| 1 — Unit | 11 | 115 |
| 2 — Integration | 1 | 6 |
| 3 — Component / API | 5 | 30 |
| **Total** | **17** | **151** |

| # | Rung | Subsystem | Test file | Tests | What it pins |
|:--|:--|:--|:--|--:|:--|
| 1 | **Unit**<br>*one class,<br>neighbours mocked* | **Fleet link**<br>*rosbridge protocol* | `RosBridgeNavStatusTest` | 14 | Nav2 goal-status parsing — live vs terminal, retained-array tail, per-robot state |
| | | | `RosBridgeServiceTest` | 8 | Robot discovery, resubscribe on reconnect, retry loop, #68 buffer floor |
| | | **Robot telemetry** | `RobotServiceTest` | 15 | Position from RobotStatus, quaternion → yaw, the 20 s freshness window |
| | | **Dispatch pipeline**<br>*real staged map* | `DispatchAssignmentTest` | 9 | FIFO assignment, the counter invariant, skip vs queue |
| | | | `DispatchRecoveryTest` | 11 | Lost and aborted goals, grace window, attempt cap, the 2026-08-11 stall |
| | | | `DispatchHomingTest` | 6 | Homing, silent robots, free-xor-busy invariant |
| | | **Map** | `DropPointMapTest` | 3 | Jackson binding for the staged shape |
| | | | `DropPointServiceTest` | 7 | Staged file loads, duplicate ids, missing file |
| | | **Orders — domain** | `OrderStatusTest` | 11 | `@JsonValue` / `@JsonCreator` both directions, and what it refuses |
| | | | `DynamoDbValueMapperTest` | 15 | All nine DynamoDB type branches, nesting, key order |
| | | | `OrderServiceTest` | 16 | `normalizeOrder` aliases, table flattening, sort order, broadcast |
| 2 | **Integration**<br>*real context,<br>edges mocked* | **Application assembly** | `ApplicationContextTest` | 6 | Context starts, beans present, map loaded, nav endpoint absent |
| 3 | **Component / API**<br>*real HTTP,<br>services mocked* | **Dispatch diagnostics**<br>`GET /api/dispatch` | `DispatchControllerTest` | 7 | Every field name, enum form, deadline never leaks, CORS origin |
| | | **Orders API**<br>`/api/orders` | `OrderControllerTest` | 11 | `ApiResponse` envelope, 404 paths, 400 on a bad status |
| | | **DynamoDB health**<br>`GET /api/dynamodb/health` | `DynamoDbControllerTest` | 3 | 200 reachable, 500 unreachable, names the table it probed |
| | | **Bench nav**<br>`/api/nav/*` | `NavTestControllerTest` | 6 | 200 / 404 / 503 / 502, and the resolved pose actually published |
| | | | `NavTestControllerDisabledTest` | 3 | All routes 404 when the flag is off |

> **Rung 1½.** The 26 dispatch tests and 4 of the 7 `DropPointServiceTest` tests load the
> real staged `drop-points.json` through real Jackson, so they are strictly unit tests with
> an integration sliver. Deliberate — faking the restaurant's geometry would make
> `sizesTheDeadlineByDistance` meaningless.